### PR TITLE
Add Japanese (ja) localization

### DIFF
--- a/Off Day/InfoPlist.xcstrings
+++ b/Off Day/InfoPlist.xcstrings
@@ -10,6 +10,12 @@
             "value" : "Off Day"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Off Day"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -40,6 +46,12 @@
             "value" : "Off Day"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Off Day"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -67,6 +79,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Notifications are used to alert you about upcoming off-day or workday."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休日・出勤日の事前通知に使用します。"
           }
         },
         "zh-Hans" : {

--- a/Off Day/Localizable.xcstrings
+++ b/Off Day/Localizable.xcstrings
@@ -26,6 +26,12 @@
             "state" : "translated",
             "value" : "%@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
         }
       }
     },
@@ -53,6 +59,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作完成"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作完了"
           }
         }
       }
@@ -83,6 +95,12 @@
             "state" : "translated",
             "value" : "建議使用英文字母和阿拉伯數字"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "半角英数字の使用を推奨します。"
+          }
         }
       }
     },
@@ -111,6 +129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "輸入自定義文件夾名"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダ名を入力"
           }
         }
       }
@@ -141,6 +165,12 @@
             "state" : "translated",
             "value" : "導入數據庫將會刪除所有現有數據"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベースのインポートにより、既存データがすべて削除されます。"
+          }
         }
       }
     },
@@ -166,6 +196,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作失敗"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作失敗"
@@ -199,6 +235,12 @@
             "state" : "translated",
             "value" : "操作成功"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作完了"
+          }
         }
       }
     },
@@ -226,6 +268,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
           }
         }
       }
@@ -256,6 +304,12 @@
             "state" : "translated",
             "value" : "導出數據庫文件"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベースファイルをエクスポート"
+          }
         }
       }
     },
@@ -284,6 +338,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "導入數據庫文件"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベースファイルをインポート"
           }
         }
       }
@@ -314,6 +374,12 @@
             "state" : "translated",
             "value" : "立即備份"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐバックアップ"
+          }
         }
       }
     },
@@ -342,6 +408,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件夾名"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダ名"
           }
         }
       }
@@ -372,6 +444,12 @@
             "state" : "translated",
             "value" : "最近備份"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最終バックアップ"
+          }
         }
       }
     },
@@ -400,6 +478,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動備份"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動バックアップ"
           }
         }
       }
@@ -430,6 +514,12 @@
             "state" : "translated",
             "value" : "導入數據庫將會刪除所有現有數據。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベースのインポートにより、既存データがすべて削除されます。"
+          }
         }
       }
     },
@@ -458,6 +548,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "數據庫"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベース"
           }
         }
       }
@@ -488,6 +584,12 @@
             "state" : "translated",
             "value" : "iCloud備份信息"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloudバックアップ情報"
+          }
         }
       }
     },
@@ -515,6 +617,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "數據庫文件將會自動同步到iCloud裏的'Off Day'文件夾。每天最多備份一次。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベースファイルはiCloudの「Off Day」フォルダに自動的にバックアップされます。1日1回まで。"
           }
         }
       }
@@ -545,6 +653,12 @@
             "state" : "translated",
             "value" : "此功能需要iCloud雲碟訪問權限。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この機能にはiCloud Driveへのアクセスが必要です。"
+          }
         }
       }
     },
@@ -572,6 +686,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "備份"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックアップ"
           }
         }
       }
@@ -631,6 +751,18 @@
               }
             }
           }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%i日"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -658,6 +790,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "再休息"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "あと"
           }
         }
       }
@@ -687,6 +825,12 @@
             "state" : "translated",
             "value" : "循環開始於"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サイクル開始日"
+          }
         }
       }
     },
@@ -714,6 +858,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "先工作"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出勤"
           }
         }
       }
@@ -743,6 +893,12 @@
             "state" : "translated",
             "value" : "休息日類型"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休日タイプ"
+          }
         }
       }
     },
@@ -770,6 +926,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選中的日子將作爲休息日"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択した曜日が休日として設定されます"
           }
         }
       }
@@ -799,6 +961,12 @@
             "state" : "translated",
             "value" : "多日循環（輪休/倒班）"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日数サイクル（シフト）"
+          }
         }
       }
     },
@@ -826,6 +994,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "固定休息日"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定休日"
           }
         }
       }
@@ -855,6 +1029,12 @@
             "state" : "translated",
             "value" : "多週循環（大小週）"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週サイクル"
+          }
         }
       }
     },
@@ -879,6 +1059,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2週"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2週"
@@ -911,6 +1097,12 @@
             "state" : "translated",
             "value" : "3週"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3週"
+          }
         }
       }
     },
@@ -935,6 +1127,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4週"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "4週"
@@ -967,6 +1165,12 @@
             "state" : "translated",
             "value" : "5週"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5週"
+          }
         }
       }
     },
@@ -991,6 +1195,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6週"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "6週"
@@ -1023,6 +1233,12 @@
             "state" : "translated",
             "value" : "7週"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7週"
+          }
         }
       }
     },
@@ -1047,6 +1263,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8週"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "8週"
@@ -1079,6 +1301,12 @@
             "state" : "translated",
             "value" : "9週"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "9週"
+          }
         }
       }
     },
@@ -1103,6 +1331,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10週"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "10週"
@@ -1135,6 +1369,12 @@
             "state" : "translated",
             "value" : "一次循環包含"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サイクル週数"
+          }
         }
       }
     },
@@ -1162,6 +1402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從%1$@到%2$@的用戶標註將全部更新爲%3$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@から\n%2$@までのユーザー注釈をすべて%3$@に変更します。"
           }
         }
       }
@@ -1191,6 +1437,12 @@
             "state" : "translated",
             "value" : "從%1$@到%2$@的用戶標註將全部刪除，變爲空白"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@から\n%2$@までのユーザー注釈をすべて消去します。"
+          }
         }
       }
     },
@@ -1218,6 +1470,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此操作一旦執行將不可撤銷"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告：この操作は元に戻せません。"
           }
         }
       }
@@ -1247,6 +1505,12 @@
             "state" : "translated",
             "value" : "取消"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
         }
       }
     },
@@ -1275,6 +1539,12 @@
             "state" : "translated",
             "value" : "執行"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実行"
+          }
         }
       }
     },
@@ -1299,6 +1569,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新"
@@ -1331,6 +1607,12 @@
             "state" : "translated",
             "value" : "結束日期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終了日"
+          }
         }
       }
     },
@@ -1358,6 +1640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "起始日期"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始日"
           }
         }
       }
@@ -1387,6 +1675,12 @@
             "state" : "translated",
             "value" : "此處修改將會覆蓋對應日期段裏的全部用戶標註，請謹慎修改。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ここでの変更は選択した日付範囲内のすべてのユーザー注釈を上書きします。慎重に操作してください。"
+          }
         }
       }
     },
@@ -1414,6 +1708,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "單次可以更新不超過1000天的記錄。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一度に最大1,000日分のレコードを更新できます。"
           }
         }
       }
@@ -1443,6 +1743,12 @@
             "state" : "translated",
             "value" : "批量編輯器"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一括編集"
+          }
         }
       }
     },
@@ -1470,6 +1776,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         }
       }
@@ -1499,6 +1811,12 @@
             "state" : "translated",
             "value" : "關閉"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じる"
+          }
         }
       }
     },
@@ -1526,6 +1844,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
           }
         }
       }
@@ -1555,6 +1879,12 @@
             "state" : "translated",
             "value" : "好的"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
         }
       }
     },
@@ -1579,6 +1909,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存"
@@ -1611,6 +1947,12 @@
             "state" : "translated",
             "value" : "今年"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今年"
+          }
         }
       }
     },
@@ -1639,6 +1981,12 @@
             "state" : "translated",
             "value" : "%i"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%i年"
+          }
         }
       }
     },
@@ -1663,6 +2011,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "衝突日"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "衝突日"
@@ -1695,6 +2049,12 @@
             "state" : "translated",
             "value" : "休息日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休日"
+          }
         }
       }
     },
@@ -1719,6 +2079,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閏"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "閏"
@@ -1751,6 +2117,12 @@
             "state" : "translated",
             "value" : "用戶文本備註：%@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザーテキストメモ：%@"
+          }
         }
       }
     },
@@ -1778,6 +2150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加備註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを追加"
           }
         }
       }
@@ -1807,6 +2185,12 @@
             "state" : "translated",
             "value" : "編輯備註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを編集"
+          }
         }
       }
     },
@@ -1834,6 +2218,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無備註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモなし"
           }
         }
       }
@@ -1863,6 +2253,12 @@
             "state" : "translated",
             "value" : "基礎日曆"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ベースカレンダー"
+          }
         }
       }
     },
@@ -1890,6 +2286,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "批量設置用戶標註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー注釈を一括設定"
           }
         }
       }
@@ -1919,6 +2321,12 @@
             "state" : "translated",
             "value" : "無公共假期模板"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日テンプレートなし"
+          }
         }
       }
     },
@@ -1946,6 +2354,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日曆"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カレンダー"
           }
         }
       }
@@ -1975,6 +2389,12 @@
             "state" : "translated",
             "value" : "日誌"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログ"
+          }
         }
       }
     },
@@ -2002,6 +2422,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更多"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
           }
         }
       }
@@ -2031,6 +2457,12 @@
             "state" : "translated",
             "value" : "取消"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
         }
       }
     },
@@ -2055,6 +2487,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存"
@@ -2087,6 +2525,12 @@
             "state" : "translated",
             "value" : "公共假期模板"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日テンプレート"
+          }
         }
       }
     },
@@ -2114,6 +2558,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "教程"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チュートリアル"
           }
         }
       }
@@ -2143,6 +2593,12 @@
             "state" : "translated",
             "value" : "日期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付"
+          }
         }
       }
     },
@@ -2170,6 +2626,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日數"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日数"
           }
         }
       }
@@ -2199,6 +2661,12 @@
             "state" : "translated",
             "value" : "%2$@這一天是：%1$@，基礎日曆信息：%3$@，公共假期信息：%4$@，用戶自定義信息：%5$@，%6$@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$@この日は%1$@、ベースカレンダー：%3$@、祝日：%4$@、カスタム：%5$@、%6$@"
+          }
         }
       }
     },
@@ -2226,6 +2694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无信息"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "情報なし"
           }
         }
       }
@@ -2255,6 +2729,12 @@
             "state" : "translated",
             "value" : "備註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモ"
+          }
         }
       }
     },
@@ -2283,6 +2763,12 @@
             "state" : "translated",
             "value" : "文字長度在1-200範圍內"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1〜200文字で入力してください。"
+          }
         }
       }
     },
@@ -2307,6 +2793,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空白"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "空白"
@@ -2339,6 +2831,12 @@
             "state" : "translated",
             "value" : "休息日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休日"
+          }
         }
       }
     },
@@ -2366,6 +2864,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "休息日類型"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付タイプ"
           }
         }
       }
@@ -2395,6 +2899,12 @@
             "state" : "translated",
             "value" : "工作日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出勤日"
+          }
         }
       }
     },
@@ -2422,6 +2932,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加備註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを追加"
           }
         }
       }
@@ -2451,6 +2967,12 @@
             "state" : "translated",
             "value" : "標記爲"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム設定"
+          }
         }
       }
     },
@@ -2478,6 +3000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "雙擊選中或取消選中，“休息日”選項和“工作日”選項最多隻會有一個被選中。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダブルタップで選択・解除。休日と出勤日はどちらか一方のみ選択できます。"
           }
         }
       }
@@ -2507,6 +3035,12 @@
             "state" : "translated",
             "value" : "休息日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休日"
+          }
         }
       }
     },
@@ -2534,6 +3068,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "雙擊選中或取消選中，“休息日”選項和“工作日”選項最多隻會有一個被選中。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダブルタップで選択・解除。休日と出勤日はどちらか一方のみ選択できます。"
           }
         }
       }
@@ -2563,6 +3103,12 @@
             "state" : "translated",
             "value" : "工作日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出勤日"
+          }
         }
       }
     },
@@ -2590,6 +3136,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從哪天往後查找？"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "どの日以降？"
           }
         }
       }
@@ -2620,6 +3172,12 @@
             "state" : "translated",
             "value" : "獲取 ${date}一日的詳情"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}の詳細を取得"
+          }
         }
       }
     },
@@ -2647,6 +3205,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "如果結果爲 true 則是衝突日。衝突日意味着這一日的用戶標註信息（可選）、公共假期模板以及基礎日曆對於“這一日是否是休息日”的判斷是不同的。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果がtrueの場合は衝突日です。衝突日とは、この日の祝日テンプレート・ベースカレンダー・ユーザー注釈（任意）で休日かどうかの判断が異なることを意味します。"
           }
         }
       }
@@ -2676,6 +3240,12 @@
             "state" : "translated",
             "value" : "如果結果爲 true 則是休息日，反之則是工作日。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果がtrueの場合は休日、そうでない場合は出勤日です。"
+          }
         }
       }
     },
@@ -2703,6 +3273,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "包含用戶標註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー注釈を含む"
           }
         }
       }
@@ -2732,6 +3308,12 @@
             "state" : "translated",
             "value" : "幾日後是否是休息日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "n日後が休日かどうか"
+          }
         }
       }
     },
@@ -2759,6 +3341,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "指定日期是否是休息日"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指定した日付が休日かどうか"
           }
         }
       }
@@ -2788,6 +3376,12 @@
             "state" : "translated",
             "value" : "今日是否是休息日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日が休日かどうか"
+          }
         }
       }
     },
@@ -2815,6 +3409,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "明日是否是休息日"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日が休日かどうか"
           }
         }
       }
@@ -2844,6 +3444,12 @@
             "state" : "translated",
             "value" : "幾日後是否是衝突日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "n日後が衝突日かどうか"
+          }
         }
       }
     },
@@ -2871,6 +3477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "指定日期是否是衝突日"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指定した日付が衝突日かどうか"
           }
         }
       }
@@ -2900,6 +3512,12 @@
             "state" : "translated",
             "value" : "今日是否是衝突日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日が衝突日かどうか"
+          }
         }
       }
     },
@@ -2927,6 +3545,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "明日是否是衝突日"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日が衝突日かどうか"
           }
         }
       }
@@ -2956,6 +3580,12 @@
             "state" : "translated",
             "value" : "用戶文本備註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザーテキストメモ"
+          }
         }
       }
     },
@@ -2983,6 +3613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "備註內容"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内容"
           }
         }
       }
@@ -3012,6 +3648,12 @@
             "state" : "translated",
             "value" : "根據日期刪除用戶文本備註。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付でユーザーテキストメモを削除します。"
+          }
         }
       }
     },
@@ -3039,6 +3681,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除備註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを削除"
           }
         }
       }
@@ -3068,6 +3716,12 @@
             "state" : "translated",
             "value" : "刪除${date}的備註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}のメモを削除"
+          }
         }
       }
     },
@@ -3095,6 +3749,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "根據日期獲取用戶文本備註，如果沒有備註，返回“沒有值”。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付でユーザーテキストメモを取得します。メモがない場合は値なしを返します。"
           }
         }
       }
@@ -3124,6 +3784,12 @@
             "state" : "translated",
             "value" : "獲取備註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを取得"
+          }
         }
       }
     },
@@ -3151,6 +3817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "獲取${date}的備註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}のメモを取得"
           }
         }
       }
@@ -3180,6 +3852,12 @@
             "state" : "translated",
             "value" : "根據日期更新文本備註爲備註內容，如果備註內容爲空，且對應日期已有文本備註，則會刪除已有的文本備註。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付でユーザーテキストメモを指定の内容に更新します。内容がない場合は既存のメモを削除します。"
+          }
         }
       }
     },
@@ -3207,6 +3885,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新備註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを更新"
           }
         }
       }
@@ -3236,6 +3920,12 @@
             "state" : "translated",
             "value" : "更新${date}的備註爲${content}"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}のメモを${content}に更新"
+          }
         }
       }
     },
@@ -3263,6 +3953,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "基礎日曆休息日狀態"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ベースカレンダー休日状態"
           }
         }
       }
@@ -3292,6 +3988,12 @@
             "state" : "translated",
             "value" : "日期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付"
+          }
         }
       }
     },
@@ -3319,6 +4021,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一日的詳情"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日の詳細"
           }
         }
       }
@@ -3348,6 +4056,12 @@
             "state" : "translated",
             "value" : "你能根據日期獲得這日的詳情"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付で日の詳細を取得できます。"
+          }
         }
       }
     },
@@ -3375,6 +4089,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "獲取一日的詳情"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日の詳細を取得"
           }
         }
       }
@@ -3404,6 +4124,12 @@
             "state" : "translated",
             "value" : "休息日狀態"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休日状態"
+          }
         }
       }
     },
@@ -3431,6 +4157,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "公共節假日名字"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日名"
           }
         }
       }
@@ -3460,6 +4192,12 @@
             "state" : "translated",
             "value" : "公共節假日模板休息日狀態"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日テンプレート休日状態"
+          }
         }
       }
     },
@@ -3487,6 +4225,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一日的詳情"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日の詳細"
           }
         }
       }
@@ -3516,6 +4260,12 @@
             "state" : "translated",
             "value" : "用戶文本備註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザーテキストメモ"
+          }
         }
       }
     },
@@ -3544,6 +4294,12 @@
             "state" : "translated",
             "value" : "用戶標註休息日狀態"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー注釈休日状態"
+          }
         }
       }
     },
@@ -3568,6 +4324,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空白"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "空白"
@@ -3600,6 +4362,12 @@
             "state" : "translated",
             "value" : "休息日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休日"
+          }
         }
       }
     },
@@ -3627,6 +4395,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "工作日"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出勤日"
           }
         }
       }
@@ -3656,6 +4430,12 @@
             "state" : "translated",
             "value" : "用户標註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー注釈"
+          }
         }
       }
     },
@@ -3683,6 +4463,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "如果結果為 true 則此項操作成功。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果がtrueの場合、操作は成功です。"
           }
         }
       }
@@ -3712,6 +4498,12 @@
             "state" : "translated",
             "value" : "用户標註類型"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー注釈タイプ"
+          }
         }
       }
     },
@@ -3739,6 +4531,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新用户標註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー注釈を更新"
           }
         }
       }
@@ -3768,6 +4566,12 @@
             "state" : "translated",
             "value" : "用户標註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー注釈"
+          }
         }
       }
     },
@@ -3795,6 +4599,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有找到"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見つかりません"
           }
         }
       }
@@ -3824,6 +4634,12 @@
             "state" : "translated",
             "value" : "你查詢的這一日，已經不在公共假期模板的有效期內，請更新模板或者更新休息日App。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "照会した日付は祝日テンプレートの有効期間外です。テンプレートまたはOff Dayアプリを更新してください。"
+          }
         }
       }
     },
@@ -3851,6 +4667,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你能根據日期獲得下一個休息日的詳情"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付で次の休日の詳細を取得できます。"
           }
         }
       }
@@ -3880,6 +4702,12 @@
             "state" : "translated",
             "value" : "下一個休息日的詳情"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次の休日の詳細を取得"
+          }
         }
       }
     },
@@ -3907,6 +4735,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你能根據日期獲得下一個工作日的詳情"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付で次の出勤日の詳細を取得できます。"
           }
         }
       }
@@ -3936,6 +4770,12 @@
             "state" : "translated",
             "value" : "下一個工作日的詳情"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次の出勤日の詳細を取得"
+          }
         }
       }
     },
@@ -3963,6 +4803,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "訂閱"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サブスクリプション"
           }
         }
       }
@@ -3992,6 +4838,12 @@
             "state" : "translated",
             "value" : "重新整理所有已訂閱的公眾假期範本"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読中の祝日テンプレートをすべて更新"
+          }
         }
       }
     },
@@ -4019,6 +4871,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "是否同時重新整理已暫停的訂閱"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止中の購読も更新するか"
           }
         }
       }
@@ -4048,6 +4906,12 @@
             "state" : "translated",
             "value" : "包含已暫停"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止中を含む"
+          }
         }
       }
     },
@@ -4076,6 +4940,12 @@
             "state" : "translated",
             "value" : "重新整理已訂閱的範本"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読中のテンプレートを更新"
+          }
         }
       }
     },
@@ -4103,6 +4973,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新整理訂閱"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読を更新"
           }
         }
       }
@@ -4133,6 +5009,12 @@
             "state" : "translated",
             "value" : "${date}是衝突日嗎？"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}は衝突日ですか？"
+          }
         }
       }
     },
@@ -4161,6 +5043,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "${date}是休息日嗎？"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}は休日ですか？"
           }
         }
       }
@@ -4191,6 +5079,12 @@
             "state" : "translated",
             "value" : "${dayCount}日後是衝突日嗎？"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${dayCount}日後は衝突日ですか？"
+          }
         }
       }
     },
@@ -4219,6 +5113,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "${dayCount}日後是休息日嗎？"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${dayCount}日後は休日ですか？"
           }
         }
       }
@@ -4249,6 +5149,12 @@
             "state" : "translated",
             "value" : "今日是衝突日嗎？"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日は衝突日ですか？"
+          }
         }
       }
     },
@@ -4277,6 +5183,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "今日是休息日嗎？"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日は休日ですか？"
           }
         }
       }
@@ -4307,6 +5219,12 @@
             "state" : "translated",
             "value" : "明日是衝突日嗎？"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日は衝突日ですか？"
+          }
         }
       }
     },
@@ -4336,6 +5254,12 @@
             "state" : "translated",
             "value" : "明日是休息日嗎？"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日は休日ですか？"
+          }
         }
       }
     },
@@ -4363,6 +5287,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         }
       }
@@ -4392,6 +5322,12 @@
             "state" : "translated",
             "value" : "清空"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリア"
+          }
         }
       }
     },
@@ -4419,6 +5355,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此操作將永久刪除所有日誌條目。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのログエントリが完全に削除されます。"
           }
         }
       }
@@ -4448,6 +5390,12 @@
             "state" : "translated",
             "value" : "確定清空全部日誌？"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのログを削除しますか？"
+          }
         }
       }
     },
@@ -4475,6 +5423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "複製"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー"
           }
         }
       }
@@ -4504,6 +5458,12 @@
             "state" : "translated",
             "value" : "錯誤"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー"
+          }
         }
       }
     },
@@ -4531,6 +5491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "輸入參數"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力パラメータ"
           }
         }
       }
@@ -4560,6 +5526,12 @@
             "state" : "translated",
             "value" : "返回結果"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返却結果"
+          }
         }
       }
     },
@@ -4587,6 +5559,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日期類型數值：0 = 休息日，1 = 工作日。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付タイプコード：0 = 休日、1 = 出勤日。"
           }
         }
       }
@@ -4616,6 +5594,12 @@
             "state" : "translated",
             "value" : "狀態"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステータス"
+          }
         }
       }
     },
@@ -4643,6 +5627,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "時間"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時刻"
           }
         }
       }
@@ -4672,6 +5662,12 @@
             "state" : "translated",
             "value" : "類型"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイプ"
+          }
         }
       }
     },
@@ -4699,6 +5695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "捷徑指令"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Intent"
           }
         }
       }
@@ -4728,6 +5730,12 @@
             "state" : "translated",
             "value" : "訂閱"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サブスクリプション"
+          }
         }
       }
     },
@@ -4755,6 +5763,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暫無日誌。調用捷徑或訂閱模板更新時，將會在此顯示。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログはまだありません。App Intentの呼び出しや購読テンプレートの更新がここに表示されます。"
           }
         }
       }
@@ -4784,6 +5798,12 @@
             "state" : "translated",
             "value" : "清空所有日誌"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのログを削除"
+          }
         }
       }
     },
@@ -4811,6 +5831,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更早"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "それ以前"
           }
         }
       }
@@ -4840,6 +5866,12 @@
             "state" : "translated",
             "value" : "近 7 天"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去7日間"
+          }
         }
       }
     },
@@ -4867,6 +5899,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "今天"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日"
           }
         }
       }
@@ -4896,6 +5934,12 @@
             "state" : "translated",
             "value" : "昨天"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "昨日"
+          }
         }
       }
     },
@@ -4920,6 +5964,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失敗"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "失敗"
@@ -4952,6 +6002,12 @@
             "state" : "translated",
             "value" : "成功"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功"
+          }
         }
       }
     },
@@ -4979,6 +6035,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接受更新"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新を適用"
           }
         }
       }
@@ -5008,6 +6070,12 @@
             "state" : "translated",
             "value" : "暫停"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止"
+          }
         }
       }
     },
@@ -5035,6 +6103,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刷新"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
           }
         }
       }
@@ -5064,6 +6138,12 @@
             "state" : "translated",
             "value" : "拒絕更新"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新を拒否"
+          }
         }
       }
     },
@@ -5091,6 +6171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢復"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再開"
           }
         }
       }
@@ -5120,6 +6206,12 @@
             "state" : "translated",
             "value" : "訂閱"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読"
+          }
         }
       }
     },
@@ -5147,6 +6239,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "背景"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックグラウンド"
           }
         }
       }
@@ -5176,6 +6274,12 @@
             "state" : "translated",
             "value" : "捷徑"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ショートカット"
+          }
         }
       }
     },
@@ -5204,6 +6308,12 @@
             "state" : "translated",
             "value" : "用戶啟動"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ユーザー起動"
+          }
         }
       }
     },
@@ -5228,6 +6338,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手動"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "手動"
@@ -5260,6 +6376,12 @@
             "state" : "translated",
             "value" : "元資料：%@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メタデータ：%@"
+          }
         }
       }
     },
@@ -5287,6 +6409,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無變更"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更なし"
           }
         }
       }
@@ -5316,6 +6444,12 @@
             "state" : "translated",
             "value" : "經典"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クラシック"
+          }
         }
       }
     },
@@ -5343,6 +6477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默認"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルト"
           }
         }
       }
@@ -5372,6 +6512,12 @@
             "state" : "translated",
             "value" : "郵箱"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メール"
+          }
         }
       }
     },
@@ -5399,6 +6545,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小紅書"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Red Note"
           }
         }
       }
@@ -5428,6 +6580,12 @@
             "state" : "translated",
             "value" : "使用說明"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使い方"
+          }
         }
       }
     },
@@ -5455,6 +6613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "基礎日曆"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ベースカレンダー"
           }
         }
       }
@@ -5484,6 +6648,12 @@
             "state" : "translated",
             "value" : "公衆假期模板"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日テンプレート"
+          }
         }
       }
     },
@@ -5511,6 +6681,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テンプレートなし"
           }
         }
       }
@@ -5540,6 +6716,12 @@
             "state" : "translated",
             "value" : "聯絡開發者"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開発者に連絡"
+          }
         }
       }
     },
@@ -5567,6 +6749,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有想法？快和我们说！"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ご意見・ご要望はこちらへ！"
           }
         }
       }
@@ -5596,6 +6784,12 @@
             "state" : "translated",
             "value" : "數據源"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データソース"
+          }
         }
       }
     },
@@ -5620,6 +6814,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "一般"
@@ -5652,6 +6852,12 @@
             "state" : "translated",
             "value" : "更多細節"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細はこちら"
+          }
         }
       }
     },
@@ -5679,6 +6885,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日誌"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログ"
           }
         }
       }
@@ -5708,6 +6920,12 @@
             "state" : "translated",
             "value" : "獲取 ${date}後第一個休息日的詳情"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}以降の次の休日詳細"
+          }
         }
       }
     },
@@ -5735,6 +6953,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "獲取 ${date}後第一個工作日的詳情"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}以降の次の出勤日詳細"
           }
         }
       }
@@ -5764,6 +6988,12 @@
             "state" : "translated",
             "value" : "明天（%@）是自定義休息日。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日（%@）はカスタム休日です。"
+          }
         }
       }
     },
@@ -5791,6 +7021,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定義休息日通知"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム休日通知"
           }
         }
       }
@@ -5820,6 +7056,12 @@
             "state" : "translated",
             "value" : "明天（%@）是自定義工作日。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日（%@）はカスタム出勤日です。"
+          }
         }
       }
     },
@@ -5847,6 +7089,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定義工作日通知"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム出勤日通知"
           }
         }
       }
@@ -5876,6 +7124,12 @@
             "state" : "translated",
             "value" : "明天(%1$@) %2$@，是公共假期。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日（%1$@）%2$@は祝日です。"
+          }
         }
       }
     },
@@ -5903,6 +7157,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "公共假期通知"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日通知"
           }
         }
       }
@@ -5932,6 +7192,12 @@
             "state" : "translated",
             "value" : "明天(%1$@) %2$@，是公共調班日。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "明日（%1$@）%2$@は振替出勤日です。"
+          }
         }
       }
     },
@@ -5959,6 +7225,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "公共調班日通知"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "振替出勤日通知"
           }
         }
       }
@@ -6018,6 +7290,18 @@
               }
             }
           }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "祝日テンプレートの期限まであと%i日です。今すぐ更新してください。"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -6045,6 +7329,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "模板通知"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テンプレート通知"
           }
         }
       }
@@ -6074,6 +7364,12 @@
             "state" : "translated",
             "value" : "前往設置以允許通知權限"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定で通知を許可する"
+          }
         }
       }
     },
@@ -6101,6 +7397,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允許通知權限"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知を許可する"
           }
         }
       }
@@ -6130,6 +7432,12 @@
             "state" : "translated",
             "value" : "通知時間"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知時刻"
+          }
         }
       }
     },
@@ -6157,6 +7465,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將會在自定義休息日/自定義工作日開始前一天通知用戶（如果連續多日都是自定義休息日/自定義工作日，則只通知一次）"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム日の前日に通知します（複数日連続の場合は1回のみ）。"
           }
         }
       }
@@ -6186,6 +7500,12 @@
             "state" : "translated",
             "value" : "自定義休息日/自定義工作日通知"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム日通知"
+          }
         }
       }
     },
@@ -6213,6 +7533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "啓用"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知を有効にする"
           }
         }
       }
@@ -6242,6 +7568,12 @@
             "state" : "translated",
             "value" : "通知時間"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知時刻"
+          }
         }
       }
     },
@@ -6269,6 +7601,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將會在公共假期/公共調班開始前一天通知用戶（如果連續多日的公共假期名字相同，則只通知一次）"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日の前日に通知します（複数日連続の場合は1回のみ）。"
           }
         }
       }
@@ -6298,6 +7636,12 @@
             "state" : "translated",
             "value" : "公共假期/公共調班通知"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日通知"
+          }
         }
       }
     },
@@ -6325,6 +7669,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "啓用"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知を有効にする"
           }
         }
       }
@@ -6354,6 +7704,12 @@
             "state" : "translated",
             "value" : "通知時間"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知時刻"
+          }
         }
       }
     },
@@ -6381,6 +7737,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將會在公共假期模板有效期到期前五天開始通知用戶"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日テンプレートの期限5日前からアラートを送信します。"
           }
         }
       }
@@ -6410,6 +7772,12 @@
             "state" : "translated",
             "value" : "公共假期模板過期通知"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日テンプレート期限アラート"
+          }
         }
       }
     },
@@ -6438,6 +7806,12 @@
             "state" : "translated",
             "value" : "啓用"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アラートを有効にする"
+          }
         }
       }
     },
@@ -6462,6 +7836,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知管理"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "通知管理"
@@ -6494,6 +7874,12 @@
             "state" : "translated",
             "value" : "取消"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
         }
       }
     },
@@ -6521,6 +7907,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
           }
         }
       }
@@ -6550,6 +7942,12 @@
             "state" : "translated",
             "value" : "你要刪除這條記錄嗎？"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このレコードを削除しますか？"
+          }
         }
       }
     },
@@ -6577,6 +7975,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "好的"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         }
       }
@@ -6606,6 +8010,12 @@
             "state" : "translated",
             "value" : "該日期下已經存在記錄"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この日付にはすでにレコードが存在します。"
+          }
         }
       }
     },
@@ -6633,6 +8043,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         }
       }
@@ -6662,6 +8078,12 @@
             "state" : "translated",
             "value" : "日期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付"
+          }
         }
       }
     },
@@ -6689,6 +8111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
           }
         }
       }
@@ -6718,6 +8146,12 @@
             "state" : "translated",
             "value" : "名稱"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前"
+          }
         }
       }
     },
@@ -6745,6 +8179,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "類型"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイプ"
           }
         }
       }
@@ -6774,6 +8214,12 @@
             "state" : "translated",
             "value" : "新增"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加"
+          }
         }
       }
     },
@@ -6801,6 +8247,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增記錄"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付を追加"
           }
         }
       }
@@ -6830,6 +8282,12 @@
             "state" : "translated",
             "value" : "更新記錄"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付を更新"
+          }
         }
       }
     },
@@ -6854,6 +8312,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新"
@@ -6886,6 +8350,12 @@
             "state" : "translated",
             "value" : "广西壮族自治区节假日安排"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国大陸の祝日（広西版）"
+          }
         }
       }
     },
@@ -6913,6 +8383,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -6942,6 +8418,12 @@
             "state" : "translated",
             "value" : "四川省涼山彝族自治州節假日安排"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国大陸の祝日（四川涼山版）"
+          }
         }
       }
     },
@@ -6969,6 +8451,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2026年"
           }
         }
       }
@@ -6998,6 +8486,12 @@
             "state" : "translated",
             "value" : "中国内地节假日安排"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国大陸の祝日"
+          }
         }
       }
     },
@@ -7025,6 +8519,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7054,6 +8554,12 @@
             "state" : "translated",
             "value" : "宁夏回族自治区节假日安排"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国大陸の祝日（寧夏版）"
+          }
         }
       }
     },
@@ -7081,6 +8587,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7110,6 +8622,12 @@
             "state" : "translated",
             "value" : "新疆维吾尔自治区节假日安排"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国大陸の祝日（新疆版）"
+          }
         }
       }
     },
@@ -7137,6 +8655,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7166,6 +8690,12 @@
             "state" : "translated",
             "value" : "西藏自治区节假日安排"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国大陸の祝日（チベット版）"
+          }
         }
       }
     },
@@ -7193,6 +8723,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7222,6 +8758,12 @@
             "state" : "translated",
             "value" : "香港公眾假期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "香港の祝日"
+          }
         }
       }
     },
@@ -7249,6 +8791,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7278,6 +8826,12 @@
             "state" : "translated",
             "value" : "日本祝日·休日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日本の祝日・休日"
+          }
         }
       }
     },
@@ -7305,6 +8859,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋1955-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1955〜2026年"
           }
         }
       }
@@ -7334,6 +8894,12 @@
             "state" : "translated",
             "value" : "韓國法定節假日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "韓国の祝日"
+          }
         }
       }
     },
@@ -7361,6 +8927,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7390,6 +8962,12 @@
             "state" : "translated",
             "value" : "澳門公眾假期 + 公共行政工作人員補假日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マカオの祝日（公共行政補償休暇付き）"
+          }
         }
       }
     },
@@ -7417,6 +8995,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7446,6 +9030,12 @@
             "state" : "translated",
             "value" : "澳門強制性假日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マカオの強制休日"
+          }
         }
       }
     },
@@ -7473,6 +9063,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7502,6 +9098,12 @@
             "state" : "translated",
             "value" : "澳門公眾假期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マカオの祝日"
+          }
         }
       }
     },
@@ -7529,6 +9131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7558,6 +9166,12 @@
             "state" : "translated",
             "value" : "新加坡公共假期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シンガポールの祝日"
+          }
         }
       }
     },
@@ -7585,6 +9199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7614,6 +9234,12 @@
             "state" : "translated",
             "value" : "創建模板…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しいテンプレート…"
+          }
         }
       }
     },
@@ -7641,6 +9267,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テンプレートなし"
           }
         }
       }
@@ -7670,6 +9302,12 @@
             "state" : "translated",
             "value" : "導入模板…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テンプレートをインポート…"
+          }
         }
       }
     },
@@ -7697,6 +9335,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "訂閱 URL…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URLを購読…"
           }
         }
       }
@@ -7726,6 +9370,12 @@
             "state" : "translated",
             "value" : "泰國公共假期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイの祝日"
+          }
         }
       }
     },
@@ -7753,6 +9403,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7782,6 +9438,12 @@
             "state" : "translated",
             "value" : "美國聯邦假日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "米国連邦祝日"
+          }
         }
       }
     },
@@ -7809,6 +9471,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "涵蓋2024-2026年"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024〜2026年"
           }
         }
       }
@@ -7838,6 +9506,12 @@
             "state" : "translated",
             "value" : "取消"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
         }
       }
     },
@@ -7865,6 +9539,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "好的"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         }
       }
@@ -7894,6 +9574,12 @@
             "state" : "translated",
             "value" : "請輸入標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトルを入力してください"
+          }
         }
       }
     },
@@ -7921,6 +9607,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除模板"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テンプレートを削除"
           }
         }
       }
@@ -7950,6 +9642,12 @@
             "state" : "translated",
             "value" : "新增記錄"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付を追加"
+          }
         }
       }
     },
@@ -7977,6 +9675,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暫停訂閱"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読を一時停止"
           }
         }
       }
@@ -8006,6 +9710,12 @@
             "state" : "translated",
             "value" : "更新訂閱"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読を更新"
+          }
         }
       }
     },
@@ -8033,6 +9743,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢復訂閱"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読を再開"
           }
         }
       }
@@ -8062,6 +9778,12 @@
             "state" : "translated",
             "value" : "取消"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
         }
       }
     },
@@ -8089,6 +9811,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "關閉"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じる"
           }
         }
       }
@@ -8118,6 +9846,12 @@
             "state" : "translated",
             "value" : "新建自訂副本"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタム用に複製"
+          }
         }
       }
     },
@@ -8145,6 +9879,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "結束日期"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終了日"
           }
         }
       }
@@ -8174,6 +9914,12 @@
             "state" : "translated",
             "value" : "導入失敗"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インポート失敗"
+          }
         }
       }
     },
@@ -8201,6 +9947,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "導入成功"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インポート成功"
           }
         }
       }
@@ -8230,6 +9982,12 @@
             "state" : "translated",
             "value" : "上次更新"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最終更新"
+          }
         }
       }
     },
@@ -8257,6 +10015,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "元旦"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元日"
           }
         }
       }
@@ -8286,6 +10050,12 @@
             "state" : "translated",
             "value" : "備註"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモ"
+          }
         }
       }
     },
@@ -8313,6 +10083,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯備註"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを編集"
           }
         }
       }
@@ -8342,6 +10118,12 @@
             "state" : "translated",
             "value" : "添加備註…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを追加…"
+          }
         }
       }
     },
@@ -8366,6 +10148,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存"
@@ -8398,6 +10186,12 @@
             "state" : "translated",
             "value" : "來源"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソース"
+          }
         }
       }
     },
@@ -8425,6 +10219,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "複製連結"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URLをコピー"
           }
         }
       }
@@ -8454,6 +10254,12 @@
             "state" : "translated",
             "value" : "起始日期"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始日"
+          }
         }
       }
     },
@@ -8481,6 +10287,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建模板"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しいテンプレート"
           }
         }
       }
@@ -8510,6 +10322,12 @@
             "state" : "translated",
             "value" : "好的"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
         }
       }
     },
@@ -8537,6 +10355,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "起始日期不能晚於結束日期。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始日は終了日より後に設定できません。"
           }
         }
       }
@@ -8566,6 +10390,12 @@
             "state" : "translated",
             "value" : "日期無效"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効な日付"
+          }
         }
       }
     },
@@ -8593,6 +10423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         }
       }
@@ -8622,6 +10458,12 @@
             "state" : "translated",
             "value" : "刪除"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
         }
       }
     },
@@ -8649,6 +10491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你要刪除這個模板嗎？"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このテンプレートを削除しますか？"
           }
         }
       }
@@ -8678,6 +10526,12 @@
             "state" : "translated",
             "value" : "更新於 %@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新日時：%@"
+          }
         }
       }
     },
@@ -8705,6 +10559,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暫停訂閱"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止"
           }
         }
       }
@@ -8734,6 +10594,12 @@
             "state" : "translated",
             "value" : "已暫停"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止中"
+          }
         }
       }
     },
@@ -8761,6 +10627,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新整理"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
           }
         }
       }
@@ -8790,6 +10662,12 @@
             "state" : "translated",
             "value" : "恢復訂閱"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再開"
+          }
         }
       }
     },
@@ -8817,6 +10695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分享"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有"
           }
         }
       }
@@ -8846,6 +10730,12 @@
             "state" : "translated",
             "value" : "取消"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
         }
       }
     },
@@ -8873,6 +10763,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "訂閱"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読"
           }
         }
       }
@@ -8902,6 +10798,12 @@
             "state" : "translated",
             "value" : "輸入假期模板 JSON 檔案的 URL"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日プランのJSON URLを入力"
+          }
         }
       }
     },
@@ -8926,6 +10828,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://..."
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "https://..."
@@ -8958,6 +10866,12 @@
             "state" : "translated",
             "value" : "訂閱模板"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プランを購読"
+          }
         }
       }
     },
@@ -8985,6 +10899,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "該 URL 已被訂閱，同一個 URL 只能存在一個訂閱。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このURLはすでに購読中です。同じURLには1件の購読のみ設定できます。"
           }
         }
       }
@@ -9014,6 +10934,12 @@
             "state" : "translated",
             "value" : "已訂閱"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読済み"
+          }
         }
       }
     },
@@ -9041,6 +10967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "訂閱失敗"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読失敗"
           }
         }
       }
@@ -9070,6 +11002,12 @@
             "state" : "translated",
             "value" : "訂閱成功"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読しました"
+          }
         }
       }
     },
@@ -9097,6 +11035,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "中國農曆"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国カレンダー"
           }
         }
       }
@@ -9126,6 +11070,12 @@
             "state" : "translated",
             "value" : "其他日曆信息將會顯示在日期下方。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "代替カレンダーの情報が日付の下に表示されます。"
+          }
         }
       }
     },
@@ -9153,6 +11103,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "關閉"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフ"
           }
         }
       }
@@ -9182,6 +11138,12 @@
             "state" : "translated",
             "value" : "其他日曆"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "代替カレンダー"
+          }
         }
       }
     },
@@ -9209,6 +11171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一般背景色"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
           }
         }
       }
@@ -9238,6 +11206,12 @@
             "state" : "translated",
             "value" : "假期調班顏色"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "振替出勤日の色"
+          }
         }
       }
     },
@@ -9265,6 +11239,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "紅色"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "赤"
           }
         }
       }
@@ -9294,6 +11274,12 @@
             "state" : "translated",
             "value" : "隱藏"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非表示"
+          }
         }
       }
     },
@@ -9321,6 +11307,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示"
           }
         }
       }
@@ -9350,6 +11342,12 @@
             "state" : "translated",
             "value" : "日誌標籤頁"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログタブ"
+          }
         }
       }
     },
@@ -9377,6 +11375,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "“經典”選項是恢復1.6.7之前版本使用的圖標。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「クラシック」は1.6.7以前のアイコンに戻す設定です。"
           }
         }
       }
@@ -9406,6 +11410,12 @@
             "state" : "translated",
             "value" : "App圖標"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appアイコン"
+          }
         }
       }
     },
@@ -9433,6 +11443,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不記錄"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効"
           }
         }
       }
@@ -9462,6 +11478,12 @@
             "state" : "translated",
             "value" : "選擇保留的最近日誌條數，超出部分會自動清理。選擇「不記錄」僅會停止寫入新日誌，既有日誌仍會保留，如需清空請前往日誌頁面手動操作。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保持する最新のログ件数を選択します。古いエントリは自動的に削除されます。「無効」を選択した場合は新規ログの書き込みのみ停止され、既存のログは保持されます。必要に応じてログページから手動で削除してください。"
+          }
         }
       }
     },
@@ -9489,6 +11511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "100 條"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100件"
           }
         }
       }
@@ -9518,6 +11546,12 @@
             "state" : "translated",
             "value" : "10000 條"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10,000件"
+          }
         }
       }
     },
@@ -9545,6 +11579,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日誌儲存"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログ保持"
           }
         }
       }
@@ -9574,6 +11614,12 @@
             "state" : "translated",
             "value" : "無限制"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無制限"
+          }
         }
       }
     },
@@ -9601,6 +11647,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第一個標籤頁"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1番目のタブ"
           }
         }
       }
@@ -9630,6 +11682,12 @@
             "state" : "translated",
             "value" : "隱藏"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非表示"
+          }
         }
       }
     },
@@ -9657,6 +11715,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第二個標籤頁"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2番目のタブ"
           }
         }
       }
@@ -9686,6 +11750,12 @@
             "state" : "translated",
             "value" : "教程位置"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チュートリアルの入口"
+          }
         }
       }
     },
@@ -9713,6 +11783,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "藍色"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "青"
           }
         }
       }
@@ -9742,6 +11818,12 @@
             "state" : "translated",
             "value" : "綠色"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "緑"
+          }
         }
       }
     },
@@ -9769,6 +11851,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "基礎休息日顏色"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ベース休日の色"
           }
         }
       }
@@ -9798,6 +11886,12 @@
             "state" : "translated",
             "value" : "單休/雙休的選擇，會直接影響休息日的判斷。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択した週末が休日として設定されます。"
+          }
         }
       }
     },
@@ -9825,6 +11919,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "單休"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日曜"
           }
         }
       }
@@ -9854,6 +11954,12 @@
             "state" : "translated",
             "value" : "週末類型"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週末タイプ"
+          }
         }
       }
     },
@@ -9881,6 +11987,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "雙休"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "土日"
           }
         }
       }
@@ -9910,6 +12022,12 @@
             "state" : "translated",
             "value" : "無休"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
+          }
         }
       }
     },
@@ -9937,6 +12055,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跟隨系統"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムに従う"
           }
         }
       }
@@ -9966,6 +12090,12 @@
             "state" : "translated",
             "value" : "一週的第一日"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週の最初の曜日"
+          }
         }
       }
     },
@@ -9990,6 +12120,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立春"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "立春"
@@ -10022,6 +12158,12 @@
             "state" : "translated",
             "value" : "雨水"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雨水"
+          }
         }
       }
     },
@@ -10050,6 +12192,12 @@
             "state" : "translated",
             "value" : "驚蟄"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啓蟄"
+          }
         }
       }
     },
@@ -10074,6 +12222,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "春分"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "春分"
@@ -10106,6 +12260,12 @@
             "state" : "translated",
             "value" : "清明"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清明"
+          }
         }
       }
     },
@@ -10130,6 +12290,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "穀雨"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "穀雨"
@@ -10162,6 +12328,12 @@
             "state" : "translated",
             "value" : "立夏"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立夏"
+          }
         }
       }
     },
@@ -10190,6 +12362,12 @@
             "state" : "translated",
             "value" : "小滿"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小満"
+          }
         }
       }
     },
@@ -10214,6 +12392,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "芒種"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "芒種"
@@ -10246,6 +12430,12 @@
             "state" : "translated",
             "value" : "夏至"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "夏至"
+          }
         }
       }
     },
@@ -10270,6 +12460,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小暑"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "小暑"
@@ -10302,6 +12498,12 @@
             "state" : "translated",
             "value" : "大暑"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大暑"
+          }
         }
       }
     },
@@ -10326,6 +12528,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立秋"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "立秋"
@@ -10358,6 +12566,12 @@
             "state" : "translated",
             "value" : "處暑"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "処暑"
+          }
         }
       }
     },
@@ -10382,6 +12596,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "白露"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "白露"
@@ -10414,6 +12634,12 @@
             "state" : "translated",
             "value" : "秋分"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秋分"
+          }
         }
       }
     },
@@ -10438,6 +12664,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寒露"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "寒露"
@@ -10470,6 +12702,12 @@
             "state" : "translated",
             "value" : "霜降"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "霜降"
+          }
         }
       }
     },
@@ -10494,6 +12732,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立冬"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "立冬"
@@ -10526,6 +12770,12 @@
             "state" : "translated",
             "value" : "小雪"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小雪"
+          }
         }
       }
     },
@@ -10550,6 +12800,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大雪"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "大雪"
@@ -10582,6 +12838,12 @@
             "state" : "translated",
             "value" : "冬至"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "冬至"
+          }
         }
       }
     },
@@ -10606,6 +12868,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小寒"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "小寒"
@@ -10638,6 +12906,12 @@
             "state" : "translated",
             "value" : "大寒"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大寒"
+          }
         }
       }
     },
@@ -10665,6 +12939,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "接受"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適用"
           }
         }
       }
@@ -10694,6 +12974,12 @@
             "state" : "translated",
             "value" : "結束日期：%@ → %@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終了日：%@ → %@"
+          }
         }
       }
     },
@@ -10718,6 +13004,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ → %@"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ → %@"
@@ -10750,6 +13042,12 @@
             "state" : "translated",
             "value" : "備註已更新"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを更新しました"
+          }
         }
       }
     },
@@ -10777,6 +13075,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "起始日期：%@ → %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始日：%@ → %@"
           }
         }
       }
@@ -10806,6 +13110,12 @@
             "state" : "translated",
             "value" : "不接受"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拒否"
+          }
         }
       }
     },
@@ -10833,6 +13143,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         }
       }
@@ -10862,6 +13178,12 @@
             "state" : "translated",
             "value" : "暫停訂閱"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購読を一時停止"
+          }
         }
       }
     },
@@ -10889,6 +13211,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跳過這一版更新"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このバージョンをスキップ"
           }
         }
       }
@@ -10918,6 +13246,12 @@
             "state" : "translated",
             "value" : "取消"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
         }
       }
     },
@@ -10945,6 +13279,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有新的版本可供查看。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認可能な新しいバージョンがあります。"
           }
         }
       }
@@ -10974,6 +13314,12 @@
             "state" : "translated",
             "value" : "預覽"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビュー"
+          }
         }
       }
     },
@@ -11001,6 +13347,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "模板「%@」更新"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テンプレート「%@」の更新"
           }
         }
       }
@@ -11030,6 +13382,12 @@
             "state" : "translated",
             "value" : "有新的版本可供查看。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認可能な新しいバージョンがあります。"
+          }
         }
       }
     },
@@ -11057,6 +13415,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "「%@」有更新"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」が更新されました"
           }
         }
       }
@@ -11086,6 +13450,12 @@
             "state" : "translated",
             "value" : "前往設置"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定へ"
+          }
         }
       }
     },
@@ -11113,6 +13483,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "點擊查看教程"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップしてチュートリアルを見る"
           }
         }
       }
@@ -11142,6 +13518,12 @@
             "state" : "translated",
             "value" : "開啓自動化"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動化を有効にする"
+          }
         }
       }
     },
@@ -11169,6 +13551,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "“休息日鬧鐘不響！”"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「休日はアラームを鳴らさない！」"
           }
         }
       }
@@ -11198,6 +13586,12 @@
             "state" : "translated",
             "value" : "我們的目標是："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私たちの目標は…"
+          }
         }
       }
     },
@@ -11225,6 +13619,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用於一般鬧鐘"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通常アラーム用"
           }
         }
       }
@@ -11254,6 +13654,12 @@
             "state" : "translated",
             "value" : "點擊啓用通知"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップして祝日前の通知を設定"
+          }
         }
       }
     },
@@ -11281,6 +13687,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "啓用公共假期提前通知"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日通知を有効にする"
           }
         }
       }
@@ -11310,6 +13722,12 @@
             "state" : "translated",
             "value" : "點擊選擇"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップして選択"
+          }
         }
       }
     },
@@ -11337,6 +13755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇公共假期模板"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "祝日テンプレートを選択"
           }
         }
       }
@@ -11366,6 +13790,12 @@
             "state" : "translated",
             "value" : "捷徑教程"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ショートカットチュートリアル"
+          }
         }
       }
     },
@@ -11393,6 +13823,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "點擊添加"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップして追加"
           }
         }
       }
@@ -11422,6 +13858,12 @@
             "state" : "translated",
             "value" : "添加捷徑"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ショートカットを追加"
+          }
         }
       }
     },
@@ -11449,6 +13891,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用於睡眠鬧鐘"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "睡眠アラーム用"
           }
         }
       }
@@ -11479,6 +13927,12 @@
             "state" : "translated",
             "value" : "将${date}用户标注更新为${mark}？"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${date}のユーザー注釈を${mark}に更新しますか？"
+          }
         }
       }
     },
@@ -11506,6 +13960,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "https://fxwl60qzgjx.feishu.cn/wiki/XHQewsdx4ibM5Ok3UNUc6VQdnqb?from=from_copylink"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://fxwl60qzgjx.feishu.cn/wiki/XiLLwve7did2IvkhLVNccYRynjh?from=from_copylink"
           }
         }
       }
@@ -11535,6 +13995,12 @@
             "state" : "translated",
             "value" : "https://fxwl60qzgjx.feishu.cn/wiki/JnKrw8KF1iFYYHkKK6yciw2znih?from=from_copylink"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://fxwl60qzgjx.feishu.cn/wiki/IIOhwCrlbivcFdkghv0c2A1xnSh?from=from_copylink"
+          }
         }
       }
     },
@@ -11562,6 +14028,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "https://fxwl60qzgjx.feishu.cn/wiki/MYMPw67yNiRfgikTM7DckyNQnPG?from=from_copylink"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://fxwl60qzgjx.feishu.cn/wiki/JaK7wpCZRietGkkww7icGhO9nqd?from=from_copylink"
           }
         }
       }
@@ -11591,6 +14063,12 @@
             "state" : "translated",
             "value" : "https://www.icloud.com/shortcuts/9e320348949c4b89a85499b6aed38533"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://www.icloud.com/shortcuts/baede9581b5e4982b95005610c6fb7a3"
+          }
         }
       }
     },
@@ -11619,6 +14097,12 @@
             "state" : "translated",
             "value" : "https://www.icloud.com/shortcuts/9faec60881504dfca40e0c3152498de5"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://www.icloud.com/shortcuts/bdd295c9ac08441d9db0d7f06fe60980"
+          }
         }
       }
     },
@@ -11643,6 +14127,12 @@
           }
         },
         "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "今日"
@@ -11674,6 +14164,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "哪一日？"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "どの日？"
           }
         }
       }


### PR DESCRIPTION
## Summary

This PR adds Japanese (ja) localization to Off Day.

## Changes

- Added `Off Day/Localizable.xcstrings` (full Japanese translation, 414 strings)
- Added `Off Day/InfoPlist.xcstrings` (Japanese translation, 3 strings including app name and notification permission text)

## Notes

- `Off Day.xcodeproj/project.pbxproj` (`knownRegions`) has not been updated as this was done on a Windows environment without Xcode. Please add `ja` to `knownRegions` if needed.

## Translation Workflow

1. Repository & source analysis
2. Pre-translation analysis
3. AI translation
4. AI review
5. Native human review